### PR TITLE
[WIP] Migrate to Rome

### DIFF
--- a/.config/rome.rjson
+++ b/.config/rome.rjson
@@ -1,0 +1,3 @@
+// For configuration documentation see http://romefrontend.dev/#project-configuration
+name: "website-2.0"
+root: true

--- a/.config/rome.rjson
+++ b/.config/rome.rjson
@@ -1,3 +1,7 @@
 // For configuration documentation see http://romefrontend.dev/#project-configuration
 name: "website-2.0"
 root: true
+
+lint: {
+  ignore: ["node_modules"]
+}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Run TypeScript Compiler
       run: yarn tsc
    
-    - name: Run Linter
-      run: yarn lint
+    - name: Run Rome check
+      run: rome check


### PR DESCRIPTION
## Migrate to Rome
[Rome](https://romefrontend.dev/) is a new package that aims to unify the frontend toolchain ambitiously looking to replace linters, Babel, Webpack, and Jest. It was just released with support for limited linting in JavaScript/TypeScript and JSX as well as dependency and `package.json` verification. This project is still under heavy development and this PR is just a tracker for its progress. There is no rush to migrate/merge and timeline mostly depends on this project's progress, but this may motivate me to contribute :octocat: 

The goal is to unify linting under one program. Currently I use [ESLint](https://eslint.org/) for linting JS/TS/JSX files and [stylelint](https://stylelint.io/) for linting CSS files. Rome has support for linting JS using these [rules](https://romefrontend.dev/docs/lint/rules/) although there are some discrepancies between this and the ones I have enabled in my [`.eslintrc`](https://github.com/meganyin13/website-2.0/blob/master/.eslintrc). For now, there is no support for turning off these rules and from the discord it doesn't seem to be something they will be supporting in the future... Linting CSS is a planned feature.

## Requirements
There are certain features I need for migration but are missing from Rome:
- [x] Lint JS/TS/JSX
- [ ] Lint CSS
- [ ] Bug: disable lint checks in `node_modules` (these are on by default and a known issue, adding to [ignore](https://romefrontend.dev/#lint.ignore) doesn't seem to work 😕 )
- [ ] Disable/customize lint rules (according to my Discord ask unsure if this is a planned feature)
- [ ] Rome GitHub actions setup 