### PR TITLE
Use react-snap for SSR in CI

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,6 +16,10 @@ jobs:
       run: yarn install
     - name: Build frontend
       run: yarn build
+    - name: Server side rendering
+      run: |
+        yarn add --dev react-snap
+        yarn react-snap
     - name: Deploy to Firebase
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -60,5 +60,11 @@
     "stylelint": "^13.5.0",
     "stylelint-config-standard": "^20.0.0",
     "typescript": "^3.8.3"
+  },
+  "reactSnap": {
+    "puppeteerArgs": [
+      "--no-sandbox",
+      "--disable-setuid-sandbox"
+    ]
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,14 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const rootElement = document.getElementById('root');
+if (rootElement != null) {
+  if (rootElement.hasChildNodes()) {
+    ReactDOM.hydrate(<App />, rootElement);
+  } else {
+    ReactDOM.render(<App />, rootElement);
+  }
+}
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
Using react-snap for server side rendering in CI deploy. Only installing it on-demand in CD job since it's a heavy package with a postinstall script that builds Chrome.

Site still loads, and you get pre-rendered html on initial load, which is good for SEO.

<img width="500" alt="Screen Shot 2020-09-05 at 16 13 23" src="https://user-images.githubusercontent.com/4290500/92312872-103ebf00-ef93-11ea-8c3d-e3ccbdddab80.png">
