### PR TITLE
Unbreak devmegan favicon

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ const App = (props: AppProps): ReactElement => {
     <>
       <Head>
         <meta charSet="utf-8" />
-        <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+        <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="Megan Yin's website" />


### PR DESCRIPTION
## Summary

Next.js doesn't special case for `%PUBLIC_URL%`. It caused devmegan favicon to disappear in previews.

<img width="396" alt="Screen Shot 2020-11-28 at 18 57 00" src="https://user-images.githubusercontent.com/4290500/100528503-aa399080-31ab-11eb-858f-b7dba68d1699.png">

Remove it to unbreak the wonderful favicon

## Test Plan

Preview